### PR TITLE
Use same temp directory as javacomplete daemon

### DIFF
--- a/javacomplete.el
+++ b/javacomplete.el
@@ -135,7 +135,7 @@ symbol is preceded by a \".\", ignoring `company-minimum-prefix-length'."
   "create process"
   (make-network-process
    :name "javacomplete"
-   :service "/tmp/javacomplete.sock"
+   :service (concat (file-name-as-directory (getenv "TMPDIR")) "javacomplete.sock")
    :family 'local
    :buffer "*JAVA COMPLETION*"))
 


### PR DESCRIPTION
I ran into a problem wherein on OS X, java.io.tmpdir was not /tmp/ as expected. (It seems that someone on reddit ran into this as well.) Instead it was "/var/folders/c2/x46f_gm54wb5j6vpb3q3kpyh0000gn/T/". This code works to retrieve the same temp directory returned by java.io.tmpdir. When I made this change I was able to get javacomplete to work. (I was later also able to get it to stack overflow, but I think that could be my fault.)

I only tested this on an OS X system. Before merging this pull request, it might be wise to verify that this does still give you /tmp/ on your system. The easy way is `M-x eval-expression (getenv "TMPDIR")`.
